### PR TITLE
fix(security): Bump Go toolchain to 1.25.9 to clear govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.25.7]
+        go-version: [1.25.9]
 
     steps:
       - name: Checkout repository
@@ -59,7 +59,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage reports as artifact
-        if: matrix.go-version == '1.25.7'
+        if: matrix.go-version == '1.25.9'
         uses: actions/upload-artifact@v5
         with:
           name: coverage-reports
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.9'
 
       - name: Run govulncheck
         run: |
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.9'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.25.3]
+        go-version: [1.25.7]
 
     steps:
       - name: Checkout repository
@@ -59,7 +59,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage reports as artifact
-        if: matrix.go-version == '1.25.3'
+        if: matrix.go-version == '1.25.7'
         uses: actions/upload-artifact@v5
         with:
           name: coverage-reports
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.7'
 
       - name: Run govulncheck
         run: |
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.7'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,14 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        go-version: [1.25.9]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -59,7 +55,6 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage reports as artifact
-        if: matrix.go-version == '1.25.9'
         uses: actions/upload-artifact@v5
         with:
           name: coverage-reports
@@ -76,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version-file: 'go.mod'
 
       - name: Run govulncheck
         run: |
@@ -94,7 +89,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version-file: 'go.mod'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version-file: 'go.mod'
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.7'
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.9'
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.7'
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version-file: 'go.mod'
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.9'
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alvincrespo/glypto-go
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/fatih/color v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alvincrespo/glypto-go
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from **1.25.3 → 1.25.9** to resolve govulncheck findings that are blocking the **Security Audit** job on every open Dependabot PR (#18, #19, #21).

> Started this PR pinned to 1.25.7, but five additional CVEs were published between research and CI run. Re-pinned to **1.25.9** (current latest 1.25.x).

## Vulnerabilities resolved

| ID | Package | Fixed in |
|---|---|---|
| [GO-2025-4155](https://pkg.go.dev/vuln/GO-2025-4155) | `crypto/x509` HostnameError quadratic blowup (CVE-2025-61729) | 1.25.5 |
| [GO-2025-4175](https://pkg.go.dev/vuln/GO-2025-4175) | `crypto/x509` name-constraint bypass (CVE-2025-61727) | 1.25.5 |
| [GO-2026-4340](https://pkg.go.dev/vuln/GO-2026-4340) | `crypto/tls` TLS 1.3 handshake info disclosure | 1.25.6 |
| [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337) | `crypto/tls` | 1.25.7 |
| [GO-2026-4601](https://pkg.go.dev/vuln/GO-2026-4601) | `net/url` IPv6 host literal parsing | 1.25.8 |
| [GO-2026-4602](https://pkg.go.dev/vuln/GO-2026-4602) | `os` FileInfo can escape `os.Root` | 1.25.8 |
| [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) | `crypto/tls` KeyUpdate DoS | 1.25.9 |
| [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) | `crypto/x509` inefficient policy validation | 1.25.9 |
| [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) | `crypto/x509` chain building work | 1.25.9 |

## Files changed

- `go.mod` — `go 1.25.3` → `go 1.25.9`
- `.github/workflows/ci.yml` — matrix, coverage upload guard, security job, lint job
- `.github/workflows/release.yml` — release job
- `.github/workflows/dependabot-auto-merge.yml` — auto-merge job

## Test plan

- [x] `go vet ./...` clean
- [x] `go build -o bin/glypto ./cmd/glypto` succeeds
- [x] `go test -race ./...` passes
- [ ] CI Security Audit turns green on this PR
- [ ] After merge: trigger \`@dependabot rebase\` on #18, #19, #21 to unblock them

🤖 Generated with [Claude Code](https://claude.com/claude-code)