### PR TITLE
docs: Fix stale Go version and broken provider-name examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Glypto Go is a CLI tool for scraping metadata from websites using a provider-bas
 
 ## Prerequisites
 
-- **Go 1.24+** (checked in `go.mod`)
+- **Go 1.25+** (checked in `go.mod`)
 - **Dependencies**: `golang.org/x/net/html` (parsing), `spf13/cobra` (CLI), `fatih/color` (output formatting)
 
 ## Architecture
@@ -106,8 +106,8 @@ The architecture carefully avoids import cycles:
 `pkg/scraper/factory.go` provides convenience functions:
 - `CreateScraper()` - Auto-loads all default providers (OpenGraph, Twitter, StandardMeta, OtherElements)
 - `CreateScraperWithProviders(providerList)` - Create scraper with custom `[]MetadataProvider` instances
-- `CreateScraperWithProviderNames(names)` - Create scraper by provider name strings (e.g., `[]string{"opengraph", "twitter"}`)
-- `ScrapeMetadata(doc)` - One-shot scraping using default providers; returns `*Metadata`
+- `CreateScraperWithProviderNames(names)` - Create scraper by provider name strings (e.g., `[]string{"openGraph", "twitter"}`)
+- `ScrapeMetadata(doc)` - One-shot scraping using default providers; returns `(*Metadata, error)`
 
 Use `CreateScraperWithProviderNames()` for CLI scenarios where users specify providers by name. Use `CreateScraperWithProviders()` for programmatic APIs with custom provider instances.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Glypto Go is a CLI tool for scraping metadata from websites using a provider-bas
 
 ## Prerequisites
 
-- **Go 1.25+** (checked in `go.mod`)
+- **Go 1.25.9+** (checked in `go.mod`)
 - **Dependencies**: `golang.org/x/net/html` (parsing), `spf13/cobra` (CLI), `fatih/color` (output formatting)
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Glypto Go
 
 [![CI](https://github.com/alvincrespo/glypto-go/workflows/CI/badge.svg)](https://github.com/alvincrespo/glypto-go/actions)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.24-blue.svg)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/go-%3E%3D1.25-blue.svg)](https://golang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Go implementation of Glypto - a CLI tool for scraping metadata from websites using a provider-based architecture. Extract Open Graph tags, Twitter Cards, standard meta tags, and RSS/Atom feeds from web pages.
@@ -191,7 +191,7 @@ func main() {
 
     // Or use provider names for convenience
     scraperByNames, err := scraper.CreateScraperWithProviderNames([]string{
-        "opengraph", "twitter", "standardmeta",
+        "openGraph", "twitter", "meta",
     })
     if err != nil {
         log.Fatal(err)
@@ -257,7 +257,7 @@ The following providers are included by default, listed by priority:
 
 ### Prerequisites
 
-- Go 1.24 or higher
+- Go 1.25 or higher
 - Git (for cloning the repository)
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The following providers are included by default, listed by priority:
 
 ### Prerequisites
 
-- Go 1.25 or higher
+- Go 1.25.9 or higher
 - Git (for cloning the repository)
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Glypto Go
 
 [![CI](https://github.com/alvincrespo/glypto-go/workflows/CI/badge.svg)](https://github.com/alvincrespo/glypto-go/actions)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.25-blue.svg)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/go-%3E%3D1.25.9-blue.svg)](https://golang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Go implementation of Glypto - a CLI tool for scraping metadata from websites using a provider-based architecture. Extract Open Graph tags, Twitter Cards, standard meta tags, and RSS/Atom feeds from web pages.


### PR DESCRIPTION
## Summary

- **Runtime-breaking fix**: \`CreateScraperWithProviderNames\` examples in both README.md and CLAUDE.md used wrong provider keys (\`\"opengraph\"\`, \`\"standardmeta\"\`). Per [\`pkg/providers/loader.go:93-97\`](https://github.com/alvincrespo/glypto-go/blob/main/pkg/providers/loader.go#L93-L97) the registered keys are case-sensitive: \`openGraph\`, \`twitter\`, \`meta\`, \`other\`. Copy-pasted as-was, the example returned \`unknown provider: opengraph\` at runtime.
- **Stale Go version**: README badge, README Prerequisites, and CLAUDE.md Prerequisites still claimed \`Go 1.24+\` even though \`go.mod\` requires \`go 1.25.9\` since #22. Bumped all three to \`Go 1.25+\`.
- **Wrong signature note**: CLAUDE.md's factory-pattern docs said \`ScrapeMetadata(doc)\` returns \`*Metadata\`. Actual signature in \`pkg/scraper/factory.go:45\` is \`(*Metadata, error)\`.

Docs only — no code changes.

## Test plan

- [x] \`grep -nE \"1\\.24|\\\"opengraph\\\"|\\\"standardmeta\\\"\" README.md CLAUDE.md\` returns no matches
- [x] Corrected provider-name list (\`\"openGraph\", \"twitter\", \"meta\"\`) matches keys in \`pkg/providers/loader.go\`
- [ ] CI passes (no-op for docs but Lint/Audit/Test still run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)