### PR TITLE
fix(security): Bump Go to 1.25.12 to clear GO-2026-5856

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Glypto Go is a CLI tool for scraping metadata from websites using a provider-bas
 
 ## Prerequisites
 
-- **Go 1.25.9+** (checked in `go.mod`)
+- **Go 1.25.12+** (checked in `go.mod`)
 - **Dependencies**: `golang.org/x/net/html` (parsing), `spf13/cobra` (CLI), `fatih/color` (output formatting)
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Glypto Go
 
 [![CI](https://github.com/alvincrespo/glypto-go/workflows/CI/badge.svg)](https://github.com/alvincrespo/glypto-go/actions)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.25.9-blue.svg)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/go-%3E%3D1.25.12-blue.svg)](https://golang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Go implementation of Glypto - a CLI tool for scraping metadata from websites using a provider-based architecture. Extract Open Graph tags, Twitter Cards, standard meta tags, and RSS/Atom feeds from web pages.
@@ -257,7 +257,7 @@ The following providers are included by default, listed by priority:
 
 ### Prerequisites
 
-- Go 1.25.9 or higher
+- Go 1.25.12 or higher
 - Git (for cloning the repository)
 
 ### Building

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alvincrespo/glypto-go
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## Problem

The **Security Audit** CI job is failing on all three open Dependabot PRs (#29, #30, #31). The failure is not caused by any of them — it's a stale Go toolchain pin.

`govulncheck ./...` reports:

```
Vulnerability #1: GO-2026-5856  (CVE-2026-42505)
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  Standard library
    Found in: crypto/tls@go1.25.11
    Fixed in: crypto/tls@go1.25.12
    Example traces found:
      #1: pkg/cli/scrape.go:59:23: cli.fetchWebpage calls http.Get, which eventually calls tls.Conn.HandshakeContext
      #2: pkg/cli/scrape.go:65:22: cli.fetchWebpage calls http.body.Close, which eventually calls tls.Conn.Read
      #3: pkg/cli/root.go:23:24:   cli.Execute calls cobra.Command.Execute, which eventually calls tls.Conn.Write
      #4: pkg/cli/scrape.go:59:23: cli.fetchWebpage calls http.Get, which eventually calls tls.Dialer.DialContext
Process completed with exit code 3.
```

These are reachable symbol-level traces, not a module-level advisory, so `govulncheck` exits non-zero and fails the job.

## Root cause

The toolchain version is pinned through `go.mod`:

1. `go.mod` declared `go 1.25.11`.
2. Every workflow uses `actions/setup-go` with `go-version-file: 'go.mod'`, so CI installs **exactly** 1.25.11 (run log: `Attempting to download 1.25.11...` → `go version go1.25.11 linux/amd64`).
3. `setup-go` exports `GOTOOLCHAIN=local`, so Go cannot self-upgrade past the pin.
4. `crypto/tls` in 1.25.11 carries GO-2026-5856; the fix shipped in 1.25.12.

**Why it started failing:** the advisory was published **2026-07-07**. `main` last ran green on **2026-07-02** (6b2d221), five days earlier. Every PR CI run since has picked up the new advisory — `main` would fail identically if re-run today.

## Change

- `go.mod`: `go 1.25.11` → `go 1.25.12`. This is the entire fix; all five `go-version-file: 'go.mod'` references across `ci.yml`, `release.yml`, and `dependabot-auto-merge.yml` follow automatically.
- `README.md` (badge + prerequisites) and `CLAUDE.md` (prerequisites): `1.25.9` → `1.25.12`. These were already stale — they still said 1.25.9 while `go.mod` had moved to 1.25.11.

No source changes. 1.25.12 is the latest 1.25.x patch (verified against go.dev/dl).

## Verification

I could not build or test locally — Go isn't installed in my environment — so **CI is the verification** for this one. Expect Security Audit to go green.

## Follow-ups (not in this PR)

- `ci.yml` installs `govulncheck@latest`, so the job's pass/fail tracks the live advisory DB. That's reasonable for a security audit, but it does mean CI can go red with zero code changes — which is exactly what happened here.
- `govulncheck` also noted *"1 vulnerability in packages you import ... your code doesn't appear to call"* without naming it (needs `-show verbose`). I checked OSV for `golang.org/x/net@0.56.0` and it's clean, so this is most likely another stdlib package rather than something #29 addresses. Non-blocking.

Once this lands, #29/#30/#31 should go green on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)