### PR TITLE
release: Prepare v0.2.0

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -14,7 +14,7 @@ var rootCmd = &cobra.Command{
 
 It extracts metadata including titles, descriptions, images, Open Graph data,
 Twitter Cards, and RSS/Atom feeds from web pages.`,
-	Version: "0.1.0",
+	Version: "0.2.0",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -77,7 +77,7 @@ func TestRootCmdProperties(t *testing.T) {
 		t.Error("Expected Long description to be set")
 	}
 
-	if rootCmd.Version != "0.1.0" {
-		t.Errorf("Expected Version to be '0.1.0', got '%s'", rootCmd.Version)
+	if rootCmd.Version != "0.2.0" {
+		t.Errorf("Expected Version to be '0.2.0', got '%s'", rootCmd.Version)
 	}
 }


### PR DESCRIPTION
Prepares the repo for a `v0.2.0` tag. After this merges, pushing the tag is the only remaining step.

## Version bump (both files, deliberately)

| File | Change |
|---|---|
| `pkg/cli/root.go:17` | `rootCmd.Version` `0.1.0` → `0.2.0` |
| `pkg/cli/root_test.go:80` | the assertion on it, `0.1.0` → `0.2.0` |

These are coupled and have to move together. The failure modes if they don't:

- **`root.go` only** → `go test -race ./...` fails *inside the release workflow*, which stops the job before `Create GitHub Release` runs. You end up with a tag pointing at no release.
- **Neither** (just tag) → the release publishes fine, but the shipped binaries report `glypto --version` → `0.1.0`. Silent.

That's the whole diff — no functional source changes, no workflow changes.

## What ships in v0.2.0

7 commits since `v0.1.0` — all dependency bumps plus the Go 1.25.12 security fix (GO-2026-5856). Release notes are auto-generated (`generate_release_notes: true`); there's no `CHANGELOG.md` in this repo, so those notes are the changelog.

## Noted, but deliberately not changed here

`release.yml:67` passes `GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}`, and no such secret is currently configured in any scope that reaches this job:

- repo Actions secrets: `total_count: 0`
- org secrets: N/A (`owner.type = User`)
- environment secrets: 1 environment (`copilot`), 0 secrets — and the release job declares no `environment:`, so they'd be out of scope anyway

So the expression resolves to an empty string. This is **not necessarily broken** — `softprops/action-gh-release@v3` defaults its `token` input to `${{ github.token }}`, and v0.1.0 published successfully on this same action version.

An earlier revision of this PR swapped it to `secrets.GITHUB_TOKEN`. That's been dropped, for two reasons:

1. It's scope creep on a release-prep PR.
2. The two tokens aren't equivalent — releases created with the automatic `GITHUB_TOKEN` **don't trigger other workflows**. Nothing in this repo keys off `release:` events today, so it wouldn't bite now, but if `GH_TOKEN` is meant to be a PAT for future downstream automation, the correct fix is adding the secret, not renaming the variable.

Flagging it so the decision is yours, separately from the release.

## Verification

I could not run `go test` locally — Go isn't installed in my environment — so CI is the verification. `Test & Build` covers the changed assertion.

## After merge

```bash
git checkout main && git pull
git tag -a v0.2.0 -m "v0.2.0"
git push origin v0.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)